### PR TITLE
Add code to draw maps of last 7 days' change

### DIFF
--- a/notebooks/maps_us_data.ipynb
+++ b/notebooks/maps_us_data.ipynb
@@ -58,7 +58,11 @@
     "# convert after.\n",
     "cases_meta[\"Date\"] = \"object\"\n",
     "\n",
-    "cases_vertical = pd.read_csv(csv_file, dtype=cases_meta, parse_dates=[\"Date\"])\n",
+    "cases_vertical = (\n",
+    "    pd\n",
+    "    .read_csv(csv_file, dtype=cases_meta, parse_dates=[\"Date\"])   \n",
+    "    .set_index([\"FIPS\", \"Date\"], verify_integrity=True)\n",
+    ")\n",
     "cases_vertical"
    ]
   },
@@ -68,8 +72,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Slice off the last element of each time series.\n",
-    "cases = cases_vertical[cases_vertical[\"Date\"] == cases_vertical[\"Date\"].max()].set_index(\"FIPS\")\n",
+    "# As a workaround for a bug in Pandas' extension types system,\n",
+    "# we need to cast the boolean columns to ints.\n",
+    "for col in [\"Confirmed_Outlier\", \"Deaths_Outlier\", \"Recovered_Outlier\"]:\n",
+    "    cases_vertical[col] = cases_vertical[col].astype(np.int8)\n",
+    "cases_vertical"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Use Text Extensions for Pandas to collapse each time series or mask down to a single cell\n",
+    "cases, dates = util.collapse_time_series(cases_vertical, [\n",
+    "    \"Confirmed\", \"Deaths\", \"Recovered\", \n",
+    "    \"Confirmed_Outlier\", \"Deaths_Outlier\", \"Recovered_Outlier\"])\n",
     "cases"
    ]
   },
@@ -80,10 +99,36 @@
    "outputs": [],
    "source": [
     "# Normalize the Confirmed and Deaths counts by population.\n",
-    "cases[\"confirmed_per_100\"] = cases[\"Confirmed\"] / cases[\"Population\"] * 100\n",
-    "cases[\"deaths_per_100\"] = cases[\"Deaths\"] / cases[\"Population\"] * 100\n",
+    "cases[\"Confirmed_per_100\"] =  100.0 * cases[\"Confirmed\"].values / cases[\"Population\"].values.reshape(-1,1)\n",
+    "cases[\"Deaths_per_100\"] = 100.0 * cases[\"Deaths\"].values / cases[\"Population\"].values.reshape(-1,1)\n",
     "\n",
     "cases"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Slice off the last element of each time series\n",
+    "latest_cases = cases[[\"State\", \"County\", \"Population\"]].copy()\n",
+    "for col in [\"Confirmed\", \"Confirmed_per_100\", \"Deaths\", \"Deaths_per_100\"]:\n",
+    "    latest_cases[col] = cases[col].values._tensor[:,-1]\n",
+    "latest_cases"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Also show totals in the last week\n",
+    "cases_this_week = cases[[\"State\", \"County\", \"Population\"]].copy()\n",
+    "for col in [\"Confirmed\", \"Confirmed_per_100\", \"Deaths\", \"Deaths_per_100\"]:\n",
+    "    cases_this_week[col] = cases[col].values._tensor[:,-1] - cases[col].values._tensor[:,-8]\n",
+    "cases_this_week"
    ]
   },
   {
@@ -110,9 +155,9 @@
     "\n",
     "import plotly.express as px\n",
     "\n",
-    "def draw_map(col_name, label_str):\n",
+    "def draw_map(df, col_name, label_str):\n",
     "    # Each series may have NAs in different locations\n",
-    "    valid_data = cases[~cases[col_name].isna()]\n",
+    "    valid_data = df[~df[col_name].isna()]\n",
     "    \n",
     "    fig = px.choropleth(valid_data, geojson=counties, \n",
     "                        locations=[\"{:05d}\".format(f) for f in valid_data.index],\n",
@@ -138,7 +183,18 @@
    "source": [
     "# Draw a map of number of confirmed cases by county.\n",
     "# Yellow == 95th percentile\n",
-    "draw_map(\"Confirmed\", \"Confirmed Cases \")"
+    "draw_map(latest_cases, \"Confirmed\", \"Confirmed Cases \")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Draw a map of number of confirmed cases in the past 7 days by county.\n",
+    "# Yellow == 95th percentile\n",
+    "draw_map(cases_this_week, \"Confirmed\", \"Confirmed Cases this Week\")"
    ]
   },
   {
@@ -149,7 +205,18 @@
    "source": [
     "# Draw a map of number of confirmed cases per 100 residents by county\n",
     "# Yellow == 95th percentile\n",
-    "draw_map(\"confirmed_per_100\", \"Confirmed per 100\")"
+    "#draw_map(latest_cases, \"Confirmed_per_100\", \"Confirmed per 100\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Draw a map of number of confirmed cases in the last week per 100 residents by county\n",
+    "# Yellow == 95th percentile\n",
+    "draw_map(cases_this_week, \"Confirmed_per_100\", \"Confirmed per 100 this Week\")"
    ]
   },
   {
@@ -160,7 +227,7 @@
    "source": [
     "# Draw a map of number of deaths by county\n",
     "# Yellow == 95th percentile\n",
-    "draw_map(\"Deaths\", \"Total Deaths  \")"
+    "#draw_map(latest_cases, \"Deaths\", \"Total Deaths  \")"
    ]
   },
   {
@@ -171,7 +238,18 @@
    "source": [
     "# Draw a map of number of deaths per 100 residents by county\n",
     "# Yellow == 95th percentile\n",
-    "draw_map(\"deaths_per_100\", \"Deaths per 100\")"
+    "#draw_map(latest_cases, \"Deaths_per_100\", \"Deaths per 100\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Draw a map of number of deaths per 100 residents by county\n",
+    "# Yellow == 95th percentile\n",
+    "#draw_map(cases_this_week, \"Deaths_per_100\", \"Deaths per 100 this Week\")"
    ]
   },
   {


### PR DESCRIPTION
This PR adds code to `maps_us_data.ipynb` that plots cases and deaths for the last 7 days. These plots create an interesting contrast with plots of cumulative totals, because the pandemic is concentrated in different parts of the country now than it was a few weeks ago.