### PR TITLE
Upgrade Python to 3.8 and add pip to environment

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -9,9 +9,7 @@
 #
 # $ ./env.sh my_dir_name
 
-# Use Python 3.7 for now because TensorFlow and JupyterLab don't support 3.8
-# yet.
-PYTHON_VERSION=3.7
+PYTHON_VERSION=3.8
 
 ############################
 # HACK ALERT *** HACK ALERT
@@ -47,7 +45,7 @@ echo "Creating an Anaconda environment at ./${ENV_DIR}"
 # Remove the detrius of any previous runs of this script
 rm -rf ./${ENV_DIR}
 
-conda create -y -p ${ENV_DIR} python=${PYTHON_VERSION}
+conda create -y -p ${ENV_DIR} python=${PYTHON_VERSION} pip
 conda activate ./${ENV_DIR}
 
 ################################################################################


### PR DESCRIPTION
This PR includes two minor changes to `env.sh`:
* Upgrade the Python version from 3.7 to 3.8
* Add `pip` to the initial contents of the conda environment; recent versions of Anaconda don't install `pip` by default